### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Ben Faul
 maintainer=Tapinsystems <info@tapinsystems.com>
 sentence=The library to use to turn your Arduino projects into IoT devices. 
 paragraph=The CPX library feature: access to the digital ports, analog ports, TCP/IP, remote interface system over TCP and USB. 
+category=Communication
 url=http://www.tapinsystems.com/arduino/CPX
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category '' in library CPX is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format